### PR TITLE
Fix some issues

### DIFF
--- a/Deployment/aws_deploy.py
+++ b/Deployment/aws_deploy.py
@@ -18,7 +18,7 @@ class AmazonCP(DeployCP):
         super(AmazonCP, self).__init__(conf_file)
 
     def create_key_pair(self):
-        regions = list(self.conf['regions.json'].values())
+        regions = list(self.conf['regions'].values())
 
         for regions_idx in range(len(regions)):
             client = boto3.client('ec2', region_name=regions[regions_idx][:-1])
@@ -37,7 +37,7 @@ class AmazonCP(DeployCP):
                 print(e.response['Error']['Message'].upper())
 
     def create_security_group(self):
-        regions = list(self.conf['regions.json'].values())
+        regions = list(self.conf['regions'].values())
 
         for idx in range(len(regions)):
             client = boto3.client('ec2', region_name=regions[idx][:-1])

--- a/Deployment/aws_deploy.py
+++ b/Deployment/aws_deploy.py
@@ -192,7 +192,7 @@ class AmazonCP(DeployCP):
             if is_spot_request == 'True':
                 response = client.describe_instances(Filters=[{'Name': 'instance-lifecycle', 'Values': ['spot']},
                                                               {'Name': 'instance-type', 'Values': [instance_type]},
-                                                              {'Name': 'tag:Name', 'Values': protocol_name}])
+                                                              {'Name': 'tag:Name', 'Values': [protocol_name]}])
 
             else:
                 response = client.describe_instances(Filters=[{'Name': 'tag:Name', 'Values': [protocol_name]}])


### PR DESCRIPTION
Fixes two issues:
* key in protocol configuration is `regions` not `regions.json`
* filter api expects list or tuple instead of strings
```
Choose deployment task
1. Deploy Instance(s)
2. Create Key pair(s)
3. Create security group(s)
4. Get instances network data
5. Terminate machines
6. Change machines types
7. Start instances 
8. Stop instances
Your choice:4
Traceback (most recent call last):
  File "main.py", line 128, in <module>
    main()
  File "main.py", line 116, in main
    print_instances_management_menu(conf_file_path)
  File "main.py", line 50, in print_instances_management_menu
    deploy.get_network_details()
  File "/path/to/MATRIX/Deployment/deploy.py", line 108, in get_network_details
    self.get_aws_network_details()
  File "/path/to/MATRIX/Deployment/aws_deploy.py", line 195, in get_aws_network_details
    {'Name': 'tag:Name', 'Values': protocol_name}])
  File "/path/to/MATRIX/.venv/lib/python3.7/site-packages/botocore/client.py", line 320, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/path/to/MATRIX/.venv/lib/python3.7/site-packages/botocore/client.py", line 596, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/path/to/MATRIX/.venv/lib/python3.7/site-packages/botocore/client.py", line 632, in _convert_to_request_dict
    api_params, operation_model)
  File "/path/to/MATRIX/.venv/lib/python3.7/site-packages/botocore/validate.py", line 291, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter Filters[2].Values, value: Semi-Honest-BMR, type: <class 'str'>, valid types: <class 'list'>, <class 'tuple'>
```