### PR TITLE
readme: add scaleway-sdk to required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To install under Arch Linux:
 
 After You installed python 3 and pip3 you will need to install the modules MATRIX uses. To install this three modules use pip3
 
-`pip3 install --user openpyxl fabric fabric3 boto3 colorama certifi elasticsearch`
+`pip3 install --user openpyxl fabric fabric3 boto3 colorama certifi elasticsearch scaleway-sdk`
 
 **NOTE**: on some computers the following error may appear: `locale.Error: unsupported locale setting`
 To fix it, run:


### PR DESCRIPTION
The Python package `scaleway-sdk` is now required to run `main.py`.