### PR TITLE
protocol execution: fix party index

### DIFF
--- a/Execution/fabfile.py
+++ b/Execution/fabfile.py
@@ -112,7 +112,7 @@ def run_protocol(config_file, args, executable_name, working_directory):
                         else:
                             put('InstancesConfigurations/parties.conf', run('pwd'))
 
-                        run('. ./%s %s %s' % (executable_name, party_id - 1, values_str))
+                        run('. ./%s %s %s' % (executable_name, party_id, values_str))
                         with open('Execution/execution_log.log', 'a+') as log_file:
                             log_file.write('%s\n' % values_str)
 


### PR DESCRIPTION
Introduced in 79610b4d96632c346e4384fcc8de4f47dc375755, this bug
resulted in miscalculated party indices starting from -1:
https://github.com/cryptobiu/MATRIX/blob/79610b4d96632c346e4384fcc8de4f47dc375755/Execution/fabfile.py#L111