### PR TITLE
fix some deployment issues

### DIFF
--- a/Deployment/aws_deploy.py
+++ b/Deployment/aws_deploy.py
@@ -197,8 +197,8 @@ class AmazonCP(DeployCP):
                                             }]
                         )
     
-                    print('Waiting for the images to be deployed..')
-                    time.sleep(240)
+            print('Waiting for the images to be deployed..')
+            time.sleep(240)
             self.get_network_details()
 
         print('Finished to deploy machines')

--- a/Deployment/aws_deploy.py
+++ b/Deployment/aws_deploy.py
@@ -65,7 +65,7 @@ class AmazonCP(DeployCP):
         prices = client.describe_spot_price_history(InstanceTypes=[instance_type], MaxResults=1,
                                                     ProductDescriptions=['Linux/UNIX (Amazon VPC)'],
                                                     AvailabilityZone=region)
-        return prices['SpotPriceHistory'][0]['SpotPrice']
+        return float(prices['SpotPriceHistory'][0]['SpotPrice'])
 
     @staticmethod
     def get_ami_disk_size(region_name):
@@ -125,12 +125,11 @@ class AmazonCP(DeployCP):
                     if spot_request:
                         # check if price isn't too low
                         winning_bid_price = self.check_latest_price(machine_type, regions[idx])
-                        if price_bids > float(winning_bid_price):
-                            price_bids = str(winning_bid_price)
+                        request_bid = min(price_bids, winning_bid_price)
                         try:
                             response = client.request_spot_instances(
                                     DryRun=False,
-                                    SpotPrice=str(price_bids),
+                                    SpotPrice=str(request_bid),
                                     InstanceCount=number_of_instances_to_deploy,
                                     ValidUntil=new_date,
                                     LaunchSpecification=


### PR DESCRIPTION
Hi,
this should fix some issues I that appeared while I was testing ABY execution over multiple regions.

1. Fix AWS price bids with multiple regions:

    When iterating through the regions, the variable `price_bids` containing
the highest acceptable price of spot instances was changed to the a
string representation of the minimum of its current value and the
winning bid price of the current region.

    This failed in case of more than one region: The comparison between
string and float failed in the next iteration.  Also, sometimes a lower
bid price would be used in the next region.

    Additionally, the return type of `check_latest_price` is changed to
float.

2. Fix for #31 (some commits ago, the sleep was already outside of the loop)