### PR TITLE
Fix network details for 'servers' deployment

### DIFF
--- a/Deployment/deploy.py
+++ b/Deployment/deploy.py
@@ -126,7 +126,7 @@ class DeployCP:
             # read servers configuration
         elif 'servers' in cp:
             server_file = input('Enter your server file configuration: ')
-            os.system('mv %s %s/InstancesConfigurations/public_ips' % (os.getcwd(), server_file))
+            os.system('cp %s %s/InstancesConfigurations/public_ips' % (server_file, os.getcwd()))
 
             server_ips = []
             with open('%s/InstancesConfigurations/public_ips' % os.getcwd(), 'r+') as server_ips_file:


### PR DESCRIPTION
The arguments of the call to `mv` were swapped such that the provided
configuration file was used as destination of the current public_ips
file.  Also, the users configuration file should not be removed from its
current location but copied instead.